### PR TITLE
chore: add Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "schedule": [
+    "before 4am on Monday"
+  ],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "assignees": ["Ryotaverse69"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "rangeStrategy": "bump"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
Renovateの自動依存関係更新を設定します。

## 設定内容
- 毎週月曜日の午前4時前に実行
- 日本時間（Asia/Tokyo）
- dependenciesラベルを自動付与
- @Ryotaverse69 に自動アサイン
- bump戦略でバージョン更新

## 関連
- 元のPR #2はセキュリティ問題により閉じました
- クリーンなブランチで再作成